### PR TITLE
add deploy to dev yml file for Github Action

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -1,0 +1,23 @@
+name: deploy-mhs-lab-dev-env
+
+on: workflow_dispatch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+    - name: Deploy site to S3 bucket
+      run: aws s3 sync . s3://${{ secrets.S3_BUCKET }} --exclude ".git*" --delete
+
+    - name: Invalidate Cloudfront Cache
+      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
This is a PR to add a `.yml` file in `.github/workflows/` so that there can be a Github Action that pushes the repository to an S3 bucket in NEU AWS server. This will allow the website to be hosted on AWS and be viewable by the public. The github action should run on manual dispatch. I've added all the secrets to the repository, so this should run fairly smoothly, fingers crossed.